### PR TITLE
add address to get endpoint without port for r53 mapping

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,6 @@
 output "endpoint" {
   value = "${aws_db_instance.this.0.endpoint}"
 }
+output "address" {
+  value = "${aws_db_instance.this.0.address}"
+}


### PR DESCRIPTION
Hi there, i think for using this output in R53 cname  mappings we should use address instead of endpoint, since the TF endpoint returns the address+port