### PR TITLE
Add logic to check when cluster enabled

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,8 @@
 output "endpoint" {
-  value = "${aws_db_instance.this.0.endpoint}"
+  #value = "${aws_db_instance.this.0.endpoint}"
+  value = ["${compact(concat(aws_rds_cluster_instance.this.*.endpoint, aws_db_instance.this.*.endpoint))}"]
 }
 output "address" {
-  value = "${aws_db_instance.this.0.address}"
+  #value = "${aws_db_instance.this.0.address}"
+  value = "${element(compact(concat(list(var.cluster), aws_db_instance.this.*.address)), 0)}"
 }


### PR DESCRIPTION
It was necessary to add an extra validation when the cluster var is true in order to add the Aurora cluster endpoint or DB instance according to available variables in each case.